### PR TITLE
Enable sending chat messages by pressing Enter

### DIFF
--- a/WorkstationInsights/Form1.Designer.cs
+++ b/WorkstationInsights/Form1.Designer.cs
@@ -82,6 +82,7 @@
             // 
             this.inputTextBox.Location = new System.Drawing.Point(12, 380);
             this.inputTextBox.Size = new System.Drawing.Size(650, 23);
+            this.inputTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inputTextBox_KeyDown);
 
             // 
             // sendButton

--- a/WorkstationInsights/Form1.cs
+++ b/WorkstationInsights/Form1.cs
@@ -123,5 +123,14 @@ namespace WorkstationInsights
         {
             MessageBox.Show("Settings are not implemented yet.");
         }
+
+        private void inputTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                sendButton.PerformClick();
+                e.SuppressKeyPress = true; // Prevent the Enter key from being processed further (e.g., adding a newline)
+            }
+        }
     }
 }


### PR DESCRIPTION
This change allows users to send messages in the chat input box by pressing the Enter key, in addition to clicking the 'Send' button.

- Added a KeyDown event handler to the inputTextBox.
- In the handler, if the Enter key is pressed, the sendButton's Click event is triggered, and the Enter key press is suppressed to prevent a newline.