### PR TITLE
Implement chat threads functionality

### DIFF
--- a/WorkstationInsights/Form1.Designer.cs
+++ b/WorkstationInsights/Form1.Designer.cs
@@ -10,6 +10,7 @@
         private System.Windows.Forms.RichTextBox chatHistoryTextBox;
         private System.Windows.Forms.TextBox inputTextBox;
         private System.Windows.Forms.Button sendButton;
+        private System.Windows.Forms.ListBox threadsListBox; // Added
 
         /// <summary>
         /// Clean up any resources being used.
@@ -36,7 +37,9 @@
             this.chatHistoryTextBox = new System.Windows.Forms.RichTextBox();
             this.inputTextBox = new System.Windows.Forms.TextBox();
             this.sendButton = new System.Windows.Forms.Button();
+            this.threadsListBox = new System.Windows.Forms.ListBox(); // Added
 
+            this.SuspendLayout(); // Added to prevent layout issues during programmatic changes
             // 
             // toolStrip1
             // 
@@ -46,7 +49,7 @@
                 this.settingsButton});
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(800, 25);
+            this.toolStrip1.Size = new System.Drawing.Size(800, 25); // Original client size
             this.toolStrip1.TabIndex = 0;
             this.toolStrip1.Text = "toolStrip1";
 
@@ -68,41 +71,68 @@
             this.settingsButton.Text = "Settings";
             this.settingsButton.Click += new System.EventHandler(this.SettingsButton_Click);
 
+            //
+            // threadsListBox
+            //
+            this.threadsListBox.FormattingEnabled = true;
+            this.threadsListBox.ItemHeight = 15; // Default item height for Segoe UI 9pt
+            this.threadsListBox.Location = new System.Drawing.Point(0, 25); // Below toolStrip1
+            this.threadsListBox.Name = "threadsListBox";
+            this.threadsListBox.Size = new System.Drawing.Size(180, 395); // Width 180, height fills below toolstrip to bottom (420-25)
+            this.threadsListBox.TabIndex = 4; // After sendButton
+            this.threadsListBox.Dock = System.Windows.Forms.DockStyle.Left; // Dock to left
+
             // 
             // chatHistoryTextBox
             // 
-            this.chatHistoryTextBox.Location = new System.Drawing.Point(12, 40);
-            this.chatHistoryTextBox.Size = new System.Drawing.Size(776, 330);
+            // Adjusted Location and Size, and Dock
+            this.chatHistoryTextBox.Location = new System.Drawing.Point(180, 28); // X = threadsListBox.Width, Y = toolStrip1.Height + small_margin
+            this.chatHistoryTextBox.Size = new System.Drawing.Size(608, 342); // Width = ClientSize.Width - threadsListBox.Width - margins, Height = ClientSize.Height - toolstrip - inputArea - margins
             this.chatHistoryTextBox.ReadOnly = true;
             this.chatHistoryTextBox.BackColor = System.Drawing.SystemColors.Window;
             this.chatHistoryTextBox.Font = new System.Drawing.Font("Segoe UI", 10F);
+            this.chatHistoryTextBox.Dock = System.Windows.Forms.DockStyle.Fill; // Fill remaining space
+            this.chatHistoryTextBox.TabIndex = 1;
+
 
             // 
             // inputTextBox
             // 
-            this.inputTextBox.Location = new System.Drawing.Point(12, 380);
-            this.inputTextBox.Size = new System.Drawing.Size(650, 23);
+            // Adjusted Location and Size, and Dock
+            this.inputTextBox.Location = new System.Drawing.Point(180, 380); // X = threadsListBox.Width
+            this.inputTextBox.Size = new System.Drawing.Size(488, 23); // Width = ClientSize.Width - threadsListBox.Width - sendButton.Width - margins
             this.inputTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.inputTextBox_KeyDown);
+            this.inputTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.inputTextBox.TabIndex = 2;
+
 
             // 
             // sendButton
             // 
-            this.sendButton.Location = new System.Drawing.Point(675, 380);
+            // Adjusted Location and Size, and Dock
+            this.sendButton.Location = new System.Drawing.Point(675, 380); // X = ClientSize.Width - sendButton.Width - margins
             this.sendButton.Size = new System.Drawing.Size(113, 23);
             this.sendButton.Text = "Send";
             this.sendButton.Click += new System.EventHandler(this.SendButton_Click);
+            this.sendButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.sendButton.TabIndex = 3;
 
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 420);
-            this.Controls.Add(this.toolStrip1);
-            this.Controls.Add(this.chatHistoryTextBox);
+            this.ClientSize = new System.Drawing.Size(800, 420); // Original client size
+            // Add threadsListBox first so other controls can dock relative to it if needed.
+            this.Controls.Add(this.chatHistoryTextBox); // Dock = Fill, should be after fixed size/docked controls
             this.Controls.Add(this.inputTextBox);
             this.Controls.Add(this.sendButton);
+            this.Controls.Add(this.threadsListBox); // Dock = Left
+            this.Controls.Add(this.toolStrip1); // toolStrip is often added first or last
             this.Text = "Workstation Insights";
+            this.ResumeLayout(false); // Added
+            this.PerformLayout();
         }
 
         #endregion

--- a/WorkstationInsights/Form1.cs
+++ b/WorkstationInsights/Form1.cs
@@ -1,20 +1,35 @@
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.ChatCompletion; // Required for AuthorRole
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using System.Text.Json;
 using System.IO; // Added for file operations
+using System.Collections.Generic; // Required for List
+using System; // Required for DateTime
 
 namespace WorkstationInsights
 {
+    // Helper class for JSON serialization
+    public class SerializableChatMessage
+    {
+        public string Role { get; set; } // "User", "Assistant", "Tool", "System"
+        public string Content { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
     public partial class Form1 : Form
     {
         private string currentLogFilePath; // To store the path of the current log file
         private const string LogDirectory = "ChatLogs"; // Directory to store log files
+        private const string LogFileExtension = ".json"; // New extension
+        private Dictionary<string, string> threadFileMap = new Dictionary<string, string>(); // Maps display name to file path
 
         public Form1()
         {
             InitializeComponent();
             InitializeChatLogging(); // Initialize logging when the form loads
+            LoadChatThreads(); // Load existing chat threads into the ListBox
+            this.threadsListBox.SelectedIndexChanged += new System.EventHandler(this.ThreadsListBox_SelectedIndexChanged); // Wire up event handler
         }
 
         private void InitializeChatLogging()
@@ -29,27 +44,107 @@ namespace WorkstationInsights
             StartNewLogFile();
         }
 
-        private void StartNewLogFile()
+        private void StartNewLogFile(bool isNewSession = true)
         {
             var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-            currentLogFilePath = Path.Combine(LogDirectory, $"chatlog_{timestamp}.txt");
-            // You could write an initial message to the log file if desired, e.g.:
-            // File.AppendAllText(currentLogFilePath, $"[Session started at {DateTime.Now}]{Environment.NewLine}");
+            currentLogFilePath = Path.Combine(LogDirectory, $"chatlog_{timestamp}{LogFileExtension}");
+
+            // Initialize the JSON file with an empty array
+            // This helps in appending new messages as elements of a JSON array
+            if (isNewSession || !File.Exists(currentLogFilePath))
+            {
+                File.WriteAllText(currentLogFilePath, "[]");
+            }
         }
 
-        private void LogMessage(string sender, string message)
+        private void LogMessage(AuthorRole role, string messageContent)
         {
-            if (string.IsNullOrEmpty(currentLogFilePath)) return; // Should not happen if initialized correctly
+            if (string.IsNullOrEmpty(currentLogFilePath))
+            {
+                // This case might occur if a new chat is started, but no message has been sent yet.
+                // We need a log file path to save the message.
+                StartNewLogFile(isNewSession: true); // Ensure a log file is ready
+            }
+
+            // Ensure the log file exists and is initialized, especially if StartNewLogFile wasn't called before the first message
+            if (!File.Exists(currentLogFilePath))
+            {
+                 File.WriteAllText(currentLogFilePath, "[]"); // Initialize with empty array
+            }
+
+
+            var logEntry = new SerializableChatMessage
+            {
+                Role = role.ToString(),
+                Content = messageContent,
+                Timestamp = DateTime.UtcNow
+            };
 
             try
             {
-                File.AppendAllText(currentLogFilePath, $"[{DateTime.Now:HH:mm:ss}] {sender}: {message}{Environment.NewLine}");
+                // Read existing entries
+                var existingJson = File.ReadAllText(currentLogFilePath);
+                var messages = JsonSerializer.Deserialize<List<SerializableChatMessage>>(existingJson) ?? new List<SerializableChatMessage>();
+
+                bool isFirstUserMessageInFile = role == AuthorRole.User && !messages.Any(m => m.Role == AuthorRole.User.ToString());
+
+                // Add new entry
+                messages.Add(logEntry);
+
+                // Write all entries back
+                var updatedJson = JsonSerializer.Serialize(messages, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(currentLogFilePath, updatedJson);
+
+                // If this was the first user message, this "solidifies" the new thread, so refresh the list
+                if (isFirstUserMessageInFile)
+                {
+                    // Check if this log file is already in threadFileMap, if not, it's a new thread that needs adding.
+                    // This handles the case where "New Chat" was clicked, then the first message is sent.
+                    if (!threadFileMap.ContainsValue(currentLogFilePath))
+                    {
+                         LoadChatThreads(); // Reload all threads to include the new one and select it
+                        // Select the newly added thread. This is a bit tricky as LoadChatThreads rebuilds the list.
+                        // We need to find it again.
+                        var newThreadName = messages.First(m => m.Role == AuthorRole.User.ToString()).Content;
+                        newThreadName = newThreadName.Length > 30 ? newThreadName.Substring(0, 30) + "..." : newThreadName;
+
+                        string uniqueNameInList = FindThreadNameInListBox(newThreadName, currentLogFilePath);
+                        if(uniqueNameInList != null)
+                        {
+                           threadsListBox.SelectedItem = uniqueNameInList;
+                        }
+                    }
+                }
             }
             catch (Exception ex)
             {
-                // Handle potential I/O errors, e.g., by showing a message to the user or logging to a fallback mechanism
-                Console.WriteLine($"Error writing to log file: {ex.Message}"); // Or use a more robust error handling
+                Console.WriteLine($"Error writing to JSON log file: {ex.Message}");
+                // Consider how to handle this error in the UI, e.g., status bar message
             }
+        }
+
+        // Helper to find the actual display name in ListBox given a base name and file path
+        private string FindThreadNameInListBox(string baseName, string filePath)
+        {
+            foreach (var item in threadsListBox.Items)
+            {
+                string itemName = item.ToString();
+                if (threadFileMap.TryGetValue(itemName, out string path) && path == filePath)
+                {
+                    return itemName;
+                }
+            }
+            // Fallback if uniqueness added numbers, check baseName prefix
+            // This part could be more robust if needed by checking map directly
+            if (threadFileMap.ContainsKey(baseName) && threadFileMap[baseName] == filePath) return baseName;
+
+            // Try with potential suffixes (1), (2) etc.
+            for(int i=1; i < 100; i++) // Max 99 duplicates, adjust if necessary
+            {
+                string potentialName = $"{baseName} ({i})";
+                if (threadFileMap.ContainsKey(potentialName) && threadFileMap[potentialName] == filePath) return potentialName;
+            }
+            return null;
         }
 
         private ChatHistory chatHistory = new(); // persist across messages
@@ -60,13 +155,12 @@ namespace WorkstationInsights
             if (string.IsNullOrWhiteSpace(input)) return;
 
             chatHistoryTextBox.AppendText($"> {input}{Environment.NewLine}");
-            LogMessage("User", input); // Log user message
+            chatHistory.AddUserMessage(input);
+            LogMessage(AuthorRole.User, input);
 
             try
             {
-                var chatService = Program.KernelInstance.GetRequiredService<IChatCompletionService>();
-
-                chatHistory.AddUserMessage(input);
+                // var chatService = Program.KernelInstance.GetRequiredService<IChatCompletionService>(); // Already available via Program.ChatService
 
                 var result = await Program.ChatService.GetChatMessageContentAsync(
                     chatHistory,
@@ -81,20 +175,25 @@ namespace WorkstationInsights
                 {
                     var toolContent = result.Content ?? "No content from tool.";
                     chatHistoryTextBox.AppendText($"[Tool Response]: {toolContent}{Environment.NewLine}");
-                    LogMessage("Tool", toolContent); // Log tool response
+                    // Note: The Semantic Kernel automatically adds tool messages to chatHistory.
+                    // We might want to log it explicitly here or rely on history reconstruction if tools are complex.
+                    // For simplicity, logging it directly.
+                    LogMessage(AuthorRole.Tool, toolContent);
                 }
-                else
+                else // Assistant message
                 {
                     var aiContent = result.Content ?? "";
                     AppendMarkdownMessage("AI", aiContent);
-                    chatHistory.AddAssistantMessage(aiContent);
-                    LogMessage("AI", aiContent); // Log AI message
+                    chatHistory.AddAssistantMessage(aiContent); // SK adds this, but good to be explicit if we were managing history manually
+                    LogMessage(AuthorRole.Assistant, aiContent);
                 }
             }
             catch (Exception ex)
             {
                 chatHistoryTextBox.AppendText($"[Error]: {ex.Message}{Environment.NewLine}");
-                LogMessage("Error", ex.Message); // Log error
+                // Logging errors with a "System" role or a dedicated "Error" role might be an option.
+                // Using "System" for now as it's a general status/error.
+                LogMessage(AuthorRole.System, $"Error: {ex.Message}");
             }
 
             inputTextBox.Clear();
@@ -119,10 +218,134 @@ namespace WorkstationInsights
         private void NewChatButton_Click(object sender, EventArgs e)
         {
             chatHistoryTextBox.Clear();
-            chatHistory.Clear(); // Clear the in-memory chat history as well
-            StartNewLogFile(); // Start a new log file for the new session
-            // Optionally, log that a new chat has started in the new log file
-            LogMessage("System", "New chat session started.");
+            chatHistory.Clear();
+            StartNewLogFile(isNewSession: true);
+            threadsListBox.ClearSelected(); // Deselect any currently selected thread in the list
+            inputTextBox.Focus(); // Set focus to the input text box for a new message
+            // LogMessage(AuthorRole.System, "New chat session started."); // This will be logged with the first actual message if needed, or we can add it.
+            // For now, a new empty log file is created. The session "officially" starts with the first message.
+            // If we want to add this to the thread list immediately, we'd need a different approach.
+            // The current plan is to add to thread list after first user message.
+        }
+
+        private void LoadChatThreads()
+        {
+            threadsListBox.Items.Clear();
+            threadFileMap.Clear();
+
+            if (!Directory.Exists(LogDirectory))
+            {
+                Directory.CreateDirectory(LogDirectory); // Ensure it exists
+                return;
+            }
+
+            var logFiles = Directory.GetFiles(LogDirectory, $"*{LogFileExtension}")
+                                .OrderByDescending(f => new FileInfo(f).CreationTime) // Show newest first
+                                .ToList();
+
+            foreach (var logFile in logFiles)
+            {
+                try
+                {
+                    var json = File.ReadAllText(logFile);
+                    if (string.IsNullOrWhiteSpace(json) || json == "[]") // Skip empty or uninitialized logs
+                    {
+                        // Optionally delete empty/invalid log files here
+                        // Console.WriteLine($"Skipping empty log file: {logFile}");
+                        continue;
+                    }
+
+                    var messages = JsonSerializer.Deserialize<List<SerializableChatMessage>>(json);
+                    if (messages != null && messages.Count > 0)
+                    {
+                        var firstUserMessage = messages.FirstOrDefault(m => m.Role == AuthorRole.User.ToString());
+                        string threadName = Path.GetFileNameWithoutExtension(logFile); // Fallback name
+
+                        if (firstUserMessage != null && !string.IsNullOrWhiteSpace(firstUserMessage.Content))
+                        {
+                            threadName = firstUserMessage.Content.Length > 30
+                                ? firstUserMessage.Content.Substring(0, 30) + "..."
+                                : firstUserMessage.Content;
+                        }
+                        else // If no user message, use file name or a generic name
+                        {
+                             // Use file creation time for a more descriptive default name
+                            threadName = $"Chat {new FileInfo(logFile).CreationTime:yyyy-MM-dd HH-mm-ss}";
+                        }
+
+                        // Ensure thread name is unique in the listbox
+                        int counter = 1;
+                        string originalThreadName = threadName;
+                        while (threadsListBox.Items.Contains(threadName) || threadFileMap.ContainsKey(threadName))
+                        {
+                            threadName = $"{originalThreadName} ({counter++})";
+                        }
+
+                        threadsListBox.Items.Add(threadName);
+                        threadFileMap[threadName] = logFile;
+                    }
+                }
+                catch (JsonException jsonEx)
+                {
+                    Console.WriteLine($"Error parsing JSON from log file {logFile}: {jsonEx.Message}");
+                    // Consider how to handle corrupted log files (e.g., rename, move to an error folder)
+                }
+                catch (Exception ex) // Catch other potential errors like file access issues
+                {
+                    Console.WriteLine($"Error processing log file {logFile}: {ex.Message}");
+                }
+            }
+        }
+
+        private void ThreadsListBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (threadsListBox.SelectedItem == null) return;
+
+            string selectedThreadName = threadsListBox.SelectedItem.ToString();
+            if (threadFileMap.TryGetValue(selectedThreadName, out string logFilePath))
+            {
+                currentLogFilePath = logFilePath; // Set as current log
+                chatHistory.Clear();
+                chatHistoryTextBox.Clear();
+
+                try
+                {
+                    var json = File.ReadAllText(logFilePath);
+                    var messages = JsonSerializer.Deserialize<List<SerializableChatMessage>>(json);
+
+                    if (messages != null)
+                    {
+                        foreach (var msg in messages)
+                        {
+                            AuthorRole role = Enum.TryParse<AuthorRole>(msg.Role, true, out var parsedRole) ? parsedRole : AuthorRole.System; // Default to System if role is unknown
+                            chatHistory.AddMessage(new ChatMessageContent(role, msg.Content));
+
+                            // Repopulate UI (simplified, could be more robust)
+                            if (role == AuthorRole.User)
+                            {
+                                chatHistoryTextBox.AppendText($"> {msg.Content}{Environment.NewLine}");
+                            }
+                            else if (role == AuthorRole.Assistant)
+                            {
+                                AppendMarkdownMessage("AI", msg.Content);
+                            }
+                            else if (role == AuthorRole.Tool)
+                            {
+                                chatHistoryTextBox.AppendText($"[Tool Response]: {msg.Content}{Environment.NewLine}");
+                            }
+                             else if (role == AuthorRole.System && msg.Content.StartsWith("Error:"))
+                            {
+                                chatHistoryTextBox.AppendText($"[{msg.Role}]: {msg.Content}{Environment.NewLine}");
+                            }
+                            // System messages (like "New chat session started") might not need to be re-displayed unless they are part of the log.
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Error loading chat thread: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
         }
 
         private async void ApiKeyButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
- Added a threads listbox to display previous chat sessions.
- Chat logs are now stored in JSON format in the `ChatLogs` directory.
- Selecting a thread loads its history into the main chat view.
- Thread names are derived from the first user message.
- New chats are added to the list after the first message is sent.
- UI in Form1.Designer.cs updated to include the threads listbox and adjust other controls.