### PR TITLE
Implement rename and delete functionality for chat history threads

### DIFF
--- a/WorkstationInsights/Form1.Designer.cs
+++ b/WorkstationInsights/Form1.Designer.cs
@@ -13,6 +13,9 @@
         private System.Windows.Forms.ListBox threadsListBox;
         private System.Windows.Forms.Panel inputPanel;
         private System.Windows.Forms.Panel rightPanel;
+        private System.Windows.Forms.ContextMenuStrip threadsContextMenuStrip; // Added
+        private System.Windows.Forms.ToolStripMenuItem renameThreadMenuItem; // Added
+        private System.Windows.Forms.ToolStripMenuItem deleteThreadMenuItem; // Added
 
         protected override void Dispose(bool disposing)
         {
@@ -38,8 +41,34 @@
             this.threadsListBox = new System.Windows.Forms.ListBox();
             this.inputPanel = new System.Windows.Forms.Panel();
             this.rightPanel = new System.Windows.Forms.Panel();
+            this.threadsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components); // Added
+            this.renameThreadMenuItem = new System.Windows.Forms.ToolStripMenuItem(); // Added
+            this.deleteThreadMenuItem = new System.Windows.Forms.ToolStripMenuItem(); // Added
 
             this.SuspendLayout();
+
+            //
+            // threadsContextMenuStrip
+            //
+            this.threadsContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.renameThreadMenuItem,
+            this.deleteThreadMenuItem});
+            this.threadsContextMenuStrip.Name = "threadsContextMenuStrip";
+            this.threadsContextMenuStrip.Size = new System.Drawing.Size(118, 48);
+            //
+            // renameThreadMenuItem
+            //
+            this.renameThreadMenuItem.Name = "renameThreadMenuItem";
+            this.renameThreadMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.renameThreadMenuItem.Text = "Rename";
+            this.renameThreadMenuItem.Click += new System.EventHandler(this.RenameThreadMenuItem_Click); // Added event handler
+            //
+            // deleteThreadMenuItem
+            //
+            this.deleteThreadMenuItem.Name = "deleteThreadMenuItem";
+            this.deleteThreadMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.deleteThreadMenuItem.Text = "Delete";
+            this.deleteThreadMenuItem.Click += new System.EventHandler(this.DeleteThreadMenuItem_Click); // Added event handler
 
             // toolStrip1
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -64,6 +93,8 @@
             this.threadsListBox.Width = 180;
             this.threadsListBox.FormattingEnabled = true;
             this.threadsListBox.TabIndex = 4;
+            this.threadsListBox.ContextMenuStrip = this.threadsContextMenuStrip; // Assign context menu
+            this.threadsListBox.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ThreadsListBox_MouseDown); // Added MouseDown event
 
             // chatHistoryTextBox
             this.chatHistoryTextBox.Dock = System.Windows.Forms.DockStyle.Fill;


### PR DESCRIPTION
Allows users to right-click on a chat thread in the list to rename or delete it.

Features:
- Rename: Prompts for a new name, renames the underlying log file, and updates the UI. Handles filename sanitization and uniqueness.
- Delete: Prompts for confirmation, deletes the log file, and removes the thread from the UI.
- If the active chat is renamed or deleted, the UI updates accordingly (reloads content, clears view, or selects another thread).
- `LoadChatThreads` now uses the filename (without extension) as a fallback for the display name, improving consistency with renamed files.
- Robustness: Includes error handling for file operations and ensures UI consistency.